### PR TITLE
fix: BCP 47-compliant locale fallbacks for Unicode extensions

### DIFF
--- a/core/src/commonMain/kotlin/io/tolgee/Tolgee.kt
+++ b/core/src/commonMain/kotlin/io/tolgee/Tolgee.kt
@@ -1,9 +1,13 @@
 package io.tolgee
 
 import de.comahe.i18n4k.Locale
+import de.comahe.i18n4k.country
 import de.comahe.i18n4k.forLocaleTag
 import de.comahe.i18n4k.language
+import de.comahe.i18n4k.removeExtensions
+import de.comahe.i18n4k.script
 import de.comahe.i18n4k.toTag
+import de.comahe.i18n4k.variant
 import dev.datlag.tooling.async.suspendCatching
 import io.ktor.client.*
 import io.ktor.client.engine.*
@@ -173,23 +177,36 @@ open class Tolgee(
      * @return List of locales in fallback order (most specific to least specific)
      */
     private fun generateLocaleFallbacks(locale: Locale): List<Locale> {
-        val localeTag = locale.toTag("-")
-        val components = localeTag.split("-")
-
         val fallbacks = mutableListOf<Locale>()
+        val seenTags = mutableSetOf<String>()
 
-        // Start with the full locale
-        fallbacks.add(locale)
-
-        // Generate intermediate variations by removing components from right to left
-        for (i in components.size - 1 downTo 2) {
-            val fallbackTag = components.subList(0, i).joinToString("-")
-            fallbacks.add(forLocaleTag(fallbackTag))
+        fun addCandidate(candidate: Locale) {
+            val tagKey = candidate.toTag("-").lowercase()
+            if (seenTags.add(tagKey)) {
+                fallbacks.add(candidate)
+            }
         }
 
-        // Add base language if not already included (when components.size > 1)
-        if (components.size > 1) {
-            fallbacks.add(forLocaleTag(components[0]))
+        addCandidate(locale)
+
+        // Extensions (u, t, x) are atomic in BCP 47 and must not be truncated piecemeal.
+        val coreLocale = locale.removeExtensions()
+        if (coreLocale != locale) {
+            addCandidate(coreLocale)
+        }
+
+        val language = coreLocale.language
+        if (language.isBlank()) return fallbacks
+
+        val subtags = buildList {
+            add(language)
+            coreLocale.script.takeIf { it.isNotBlank() }?.let(::add)
+            coreLocale.country.takeIf { it.isNotBlank() }?.let(::add)
+            coreLocale.variant.takeIf { it.isNotBlank() }?.let(::add)
+        }
+
+        for (count in subtags.size - 1 downTo 1) {
+            addCandidate(forLocaleTag(subtags.take(count).joinToString("-")))
         }
 
         return fallbacks

--- a/core/src/commonMain/kotlin/io/tolgee/Tolgee.kt
+++ b/core/src/commonMain/kotlin/io/tolgee/Tolgee.kt
@@ -167,8 +167,12 @@ open class Tolgee(
      * Generates progressive fallback variations for a locale by removing components
      * from right to left following BCP 47 structure (language-script-region-variant).
      *
+     * When both script and region are present, also tries language-region (dropping script)
+     * after language-script. This matches common CDN layouts (e.g. en-Latn-US → en-US).
+     *
      * Examples:
-     * - "zh-Hans-CN" → ["zh-Hans-CN", "zh-Hans", "zh"]
+     * - "zh-Hans-CN" → ["zh-Hans-CN", "zh-Hans", "zh-CN", "zh"]
+     * - "en-Latn-US" → ["en-Latn-US", "en-Latn", "en-US", "en"]
      * - "en-US" → ["en-US", "en"]
      * - "sr-Cyrl" → ["sr-Cyrl", "sr"]
      * - "en" → ["en"]
@@ -198,16 +202,35 @@ open class Tolgee(
         val language = coreLocale.language
         if (language.isBlank()) return fallbacks
 
+        val script = coreLocale.script.takeIf { it.isNotBlank() }
+        val region = coreLocale.country.takeIf { it.isNotBlank() }
+        val variant = coreLocale.variant.takeIf { it.isNotBlank() }
+
         val subtags = buildList {
             add(language)
-            coreLocale.script.takeIf { it.isNotBlank() }?.let(::add)
-            coreLocale.country.takeIf { it.isNotBlank() }?.let(::add)
-            coreLocale.variant.takeIf { it.isNotBlank() }?.let(::add)
+            script?.let(::add)
+            region?.let(::add)
+            variant?.let(::add)
         }
 
-        for (count in subtags.size - 1 downTo 1) {
-            addCandidate(forLocaleTag(subtags.take(count).joinToString("-")))
+        val coreFallbackTags = buildList {
+            for (count in subtags.size - 1 downTo 1) {
+                add(subtags.take(count).joinToString("-"))
+            }
+        }.toMutableList()
+
+        // When both script and region are present, also try language-region (e.g. en-Latn-US → en-US).
+        // Insert after language-script so script-specific matches (zh-Hans) stay preferred over regional ones (zh-CN).
+        if (script != null && region != null) {
+            val langScriptTag = "$language-$script"
+            val langRegionTag = "$language-$region"
+            val scriptIndex = coreFallbackTags.indexOf(langScriptTag)
+            if (scriptIndex >= 0 && langRegionTag !in coreFallbackTags) {
+                coreFallbackTags.add(scriptIndex + 1, langRegionTag)
+            }
         }
+
+        coreFallbackTags.forEach { addCandidate(forLocaleTag(it)) }
 
         return fallbacks
     }
@@ -227,8 +250,8 @@ open class Tolgee(
      * a match is found.
      *
      * Examples:
-     * - "zh-Hans-CN" → "zh-Hans-CN" → "zh-Hans" → "zh" → default
-     * - "en-Latn-US" → "en-Latn-US" → "en-Latn" → "en" → default
+     * - "zh-Hans-CN" → "zh-Hans-CN" → "zh-Hans" → "zh-CN" → "zh" → default
+     * - "en-Latn-US" → "en-Latn-US" → "en-Latn" → "en-US" → "en" → default
      * - "sr-Cyrl" → "sr-Cyrl" → "sr" → default
      * - "en-US" → "en-US" → "en" → default
      *

--- a/core/src/commonTest/kotlin/io/tolgee/ResolveLocaleTest.kt
+++ b/core/src/commonTest/kotlin/io/tolgee/ResolveLocaleTest.kt
@@ -103,9 +103,23 @@ class ResolveLocaleTest {
     }
 
     @Test
-    fun fallbackFromLanguageScriptRegionToScript() {
+    fun fallbackFromLanguageScriptRegionToScriptWhenAvailable() {
         val tolgee = createTolgee(listOf(forLocaleTag("en"), forLocaleTag("en-Latn")))
         val result = tolgee.testResolveLocale(forLocaleTag("en-Latn-US"))
         assertEquals("en-Latn", result?.toTag("-"))
+    }
+
+    @Test
+    fun fallbackFromLanguageScriptRegionToRegionWhenScriptUnavailable() {
+        val tolgee = createTolgee(listOf(forLocaleTag("en"), forLocaleTag("en-US")))
+        val result = tolgee.testResolveLocale(forLocaleTag("en-Latn-US"))
+        assertEquals("en-US", result?.toTag("-"))
+    }
+
+    @Test
+    fun fallbackFromLanguageScriptRegionToRegionWhenOnlyRegionalAvailable() {
+        val tolgee = createTolgee(listOf(forLocaleTag("zh-CN")))
+        val result = tolgee.testResolveLocale(forLocaleTag("zh-Hans-CN"))
+        assertEquals("zh-CN", result?.toTag("-"))
     }
 }

--- a/core/src/commonTest/kotlin/io/tolgee/ResolveLocaleTest.kt
+++ b/core/src/commonTest/kotlin/io/tolgee/ResolveLocaleTest.kt
@@ -87,4 +87,25 @@ class ResolveLocaleTest {
         val result = tolgee.testResolveLocale(locale)
         assertEquals("zh-Hans", result?.toTag("-"))
     }
+
+    @Test
+    fun unicodeExtensionFallsBackToBaseLanguage() {
+        val tolgee = createTolgee(listOf(forLocaleTag("en"), forLocaleTag("es")))
+        val result = tolgee.testResolveLocale(forLocaleTag("es-u-ms-metric"))
+        assertEquals("es", result?.toTag("-"))
+    }
+
+    @Test
+    fun unicodeExtensionExactMatchWhenAvailable() {
+        val tolgee = createTolgee(listOf(forLocaleTag("en"), forLocaleTag("es-u-ms-metric")))
+        val result = tolgee.testResolveLocale(forLocaleTag("es-u-ms-metric"))
+        assertEquals("es-u-ms-metric", result?.toTag("-"))
+    }
+
+    @Test
+    fun fallbackFromLanguageScriptRegionToScript() {
+        val tolgee = createTolgee(listOf(forLocaleTag("en"), forLocaleTag("en-Latn")))
+        val result = tolgee.testResolveLocale(forLocaleTag("en-Latn-US"))
+        assertEquals("en-Latn", result?.toTag("-"))
+    }
 }


### PR DESCRIPTION
## Summary

- Fixes a production crash (`IllegalStateException: Value for extension key 'u' is empty! language-tag: es-u`) when resolving translations for system locales with BCP 47 Unicode extensions (e.g. `es-u-ms-metric` on Android 17).
- Replaces naive `split("-")` fallback generation with structured subtag removal using i18n4k locale components (`language`, `script`, `country`, `variant`), stripping extensions atomically via `removeExtensions()`.
- Adds `language-region` fallback when both script and region are present (e.g. `en-Latn-US` → `en-US`), inserted after `language-script` so script-specific matches like `zh-Hans-CN` → `zh-Hans` remain preferred.

Closes #20

## Problem

`generateLocaleFallbacks()` split the locale tag on `-` and removed segments from right to left. For `es-u-ms-metric` this produced invalid intermediate tags like `es-u-ms` and `es-u`. When `forLocaleTag("es-u")` was called, i18n4k correctly rejected the malformed tag.

This was observed in production on Android 17 devices with system locale `es__#u-ms-metric` (Spanish with metric-system Unicode extension).

A related pre-existing gap: locales with script and region (e.g. `en-Latn-US`) never reached regional CDN files such as `en-US` because strict truncation only produced `en-Latn` → `en`.

## Approach

1. Keep the full locale (with extensions) as the first fallback candidate for exact matches.
2. If extensions are present, add the core locale without extensions (`es`) as the next candidate.
3. Generate further fallbacks by removing structured subtags in BCP 47 order: variant → region → script → language.
4. When both script and region are present, also try `language-region` after `language-script` (e.g. `en-Latn-US` → `en-Latn` → `en-US` → `en`).

## Test plan

- [x] `./gradlew :core:testDebugUnitTest`
- [x] `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ./gradlew :core:jvmTest --tests "io.tolgee.ResolveLocaleTest"`
- [x] Unicode extension: `es-u-ms-metric` → `es` (no crash)
- [x] Unicode extension exact match when available
- [x] Script+region → region when script unavailable: `en-Latn-US` → `en-US`
- [x] Script+region → script when available: `en-Latn-US` → `en-Latn`, `zh-Hans-CN` → `zh-Hans`
- [x] All existing `ResolveLocaleTest` cases still pass